### PR TITLE
fix: prevent adding players to full side

### DIFF
--- a/src/core/LobbyService.ts
+++ b/src/core/LobbyService.ts
@@ -46,9 +46,11 @@ class LobbyService {
     const targetSide =
       side == "left" ? this.leftSideSlots : this.rightSideSlots;
 
-    if (targetSide.length < this.maxPlayersBySide) {
-      targetSide.push(player);
+    if (targetSide.length >= this.maxPlayersBySide) {
+      throw new Error(LOBBY_ERRORS.LOBBY_FULL);
     }
+
+    targetSide.push(player);
 
     if (this.isFull()) {
       this.status = LobbyStatusEnum.CONFIRMED;

--- a/test/match.test.ts
+++ b/test/match.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import LobbyService, { LobbyStatusEnum } from "../src/core/LobbyService";
+import LobbyService, { LobbyStatusEnum, LOBBY_ERRORS } from "../src/core/LobbyService";
 import PlayerType from "../src/models/Player";
 import "reflect-metadata";
 
@@ -42,5 +42,13 @@ describe("match-engine-lib", () => {
     expect(service.status).toBe(LobbyStatusEnum.CONFIRMED);
     expect(service.getAllPlayers.length).toBe(4);
     expect(() => service.addPlayer(player5, "left")).toThrow();
+  });
+
+  it("throws when adding player to a side that is full", () => {
+    const service = new LobbyService(crypto.randomUUID(), player1);
+    service.addPlayer(player2, "left");
+    expect(() => service.addPlayer(player3, "left")).toThrowError(
+      LOBBY_ERRORS.LOBBY_FULL
+    );
   });
 });


### PR DESCRIPTION
## Summary
- prevent LobbyService from silently ignoring adds to a full side
- cover side capacity check with unit test

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:54323)*

------
https://chatgpt.com/codex/tasks/task_e_689c75a5bdc883339c435d7b4de589a9